### PR TITLE
Add dataset reader for raw Omnibus NDDA Dataset

### DIFF
--- a/src/main/scala/org/allenai/deep_qa/data/Dataset.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/Dataset.scala
@@ -35,5 +35,5 @@ object DatasetReader {
   readers.put("who did what", (fileUtil) => new WhoDidWhatDatasetReader(fileUtil))
   readers.put("newsqa", (fileUtil) => new NewsQaDatasetReader(fileUtil))
   readers.put("sciq", (fileUtil) => new SciQDatasetReader(fileUtil))
-  readers.put("omnibus da", (fileUtil) => new OmnibusDaDatasetReader(fileUtil))
+  readers.put("omnibus da", (fileUtil) => new OmnibusDaDatasetReader())
 }

--- a/src/main/scala/org/allenai/deep_qa/data/Dataset.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/Dataset.scala
@@ -35,4 +35,5 @@ object DatasetReader {
   readers.put("who did what", (fileUtil) => new WhoDidWhatDatasetReader(fileUtil))
   readers.put("newsqa", (fileUtil) => new NewsQaDatasetReader(fileUtil))
   readers.put("sciq", (fileUtil) => new SciQDatasetReader(fileUtil))
+  readers.put("omnibus da", (fileUtil) => new OmnibusDaDatasetReader(fileUtil))
 }

--- a/src/main/scala/org/allenai/deep_qa/data/Instance.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/Instance.scala
@@ -121,7 +121,7 @@ case class SpanPredictionInstance(
 
 /**
   * An Instance representing a direct answer question, where the label
-  * is the string answer to the question.
+  * is a string containing possible acceptable answers for the question.
   */
 case class DirectAnswerInstance(
   question: String,

--- a/src/main/scala/org/allenai/deep_qa/data/Instance.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/Instance.scala
@@ -120,6 +120,22 @@ case class SpanPredictionInstance(
 }
 
 /**
+  * An Instance representing a direct answer question, where the label
+  * is the string answer to the question.
+  */
+case class DirectAnswerInstance(
+  question: String,
+  override val label: Option[String]
+) extends Instance {
+  def asStrings(): Seq[Seq[String]] = {
+    label match {
+      case Some(l) => Seq(Seq(s"$question\t$l"))
+      case None => Seq(Seq(s"$question"))
+    }
+  }
+}
+
+/**
   * An Instance created for the task of multiple choice
   * reading comprehension. Used by the SciQ dataset and
   * the Who Did What dataset.

--- a/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
@@ -1,0 +1,31 @@
+package org.allenai.deep_qa.data
+
+import scala.collection.mutable
+import scala.collection.JavaConverters._
+
+import com.opencsv.CSVReader
+import com.mattg.util.FileUtil
+import java.io.StringReader
+import org.json4s._
+import org.json4s.native.JsonMethods.parse
+
+/*
+ * Read an Omnibus direct answer file pulled from the Aristo
+ * evaluation framework.
+ */
+
+class OmnibusDaDatasetReader(fileUtil: FileUtil) extends DatasetReader[DirectAnswerInstance] {
+  override def readFile(filename: String): Dataset[DirectAnswerInstance] = {
+    val reader = new StringReader(fileUtil.readFileContents(filename))
+    val csv = new CSVReader(reader)
+    val instanceTuples = for {
+      line <- csv.readAll().asScala.tail
+      questionText = line(3)
+      answerText = line(4)
+    } yield (questionText, answerText)
+    val instances = instanceTuples.map { case (questionText, answerText) => {
+      DirectAnswerInstance(questionText, Some(answerText))
+    }}
+    Dataset(instances)
+  }
+}

--- a/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
@@ -14,8 +14,9 @@ import org.json4s.native.JsonMethods.parse
  * evaluation framework.
  */
 
-class OmnibusDaDatasetReader(fileUtil: FileUtil) extends DatasetReader[DirectAnswerInstance] {
+class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
   override def readFile(filename: String): Dataset[DirectAnswerInstance] = {
+    val fileUtil = new FileUtil
     val reader = new StringReader(fileUtil.readFileContents(filename))
     val csv = new CSVReader(reader)
     val instanceTuples = for {

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
@@ -11,8 +11,9 @@ object omnibusDaDatasets {
 
   def omnibusDaFile(omnibusDaDir: String, grade: String, split: String): JValue = {
     val datasetGradePath = s"Omnibus-Gr${grade}-NDDA"
-    val outputDirectory = omnibusDaDir + datasetGradePath +"/processed/"
-    val inputFile = omnibusDaDir + datasetGradePath + s"/${datasetGradePath}-${split}.csv"
+    val outputDirectory = omnibusDaDir + datasetGradePath +s"/processed/${split}/"
+    val splitCapitalized = split.capitalize
+    val inputFile = omnibusDaDir + datasetGradePath + s"/${datasetGradePath}-${splitCapitalized}.csv"
     val outputFiles = Seq(outputDirectory + s"${split}.tsv")
     ("sentence producer type" -> "dataset reader") ~
       ("reader" -> "omnibus da") ~
@@ -30,13 +31,27 @@ object omnibusDaDatasets {
   // Train files
   val omnibusNDDA04TrainFile = omnibusDaFile(baseDir, "04", "train")
   val omnibusNDDA04Train = omnibusDaDataset(baseDir, "04", "train")
+  val omnibusNDDA04TrainBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNDDA04TrainFile,
+    "question and answer",
+    ScienceCorpora.buscElasticSearchIndex(3)
+  )
 
   // Dev Files
   val omnibusNDDA04DevFile = omnibusDaFile(baseDir, "04", "dev")
   val omnibusNDDA04Dev = omnibusDaDataset(baseDir, "04", "dev")
+  val omnibusNDDA04DevBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNDDA04DevFile,
+    "question and answer",
+    ScienceCorpora.buscElasticSearchIndex(3)
+  )
 
   // Test Files
   val omnibusNDDA04TestFile = omnibusDaFile(baseDir, "04", "test")
   val omnibusNDDA04Test = omnibusDaDataset(baseDir, "04", "test")
-
+  val omnibusNDDA04TestBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNDDA04TestFile,
+    "question and answer",
+    ScienceCorpora.buscElasticSearchIndex(3)
+  )
 }

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
@@ -36,6 +36,10 @@ object omnibusDaDatasets {
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
+  val omnibusNDDA04TrainFileWithBackground: JValue =
+    ("sentence producer type" -> "combine background and instance") ~
+    ("sentences" -> omnibusNDDA04TrainFile) ~
+    ("background" -> omnibusNDDA04TrainBuscBackgroundFile)
 
   // Dev Files
   val omnibusNDDA04DevFile = omnibusDaFile(baseDir, "04", "dev")
@@ -45,6 +49,10 @@ object omnibusDaDatasets {
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
+  val omnibusNDDA04DevFileWithBackground: JValue =
+    ("sentence producer type" -> "combine background and instance") ~
+    ("sentences" -> omnibusNDDA04DevFile) ~
+    ("background" -> omnibusNDDA04DevBuscBackgroundFile)
 
   // Test Files
   val omnibusNDDA04TestFile = omnibusDaFile(baseDir, "04", "test")
@@ -54,4 +62,9 @@ object omnibusDaDatasets {
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
+  val omnibusNDDA04TestFileWithBackground: JValue =
+    ("sentence producer type" -> "combine background and instance") ~
+    ("sentences" -> omnibusNDDA04TestFile) ~
+    ("background" -> omnibusNDDA04TestBuscBackgroundFile)
+
 }

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
@@ -35,41 +35,41 @@ object OmnibusDa {
 
   val baseDir = "/efs/data/dlfa/omnibus_ndda/"
   // Train files
-  val omnibusNDDA4TrainFile = omnibusDaFile(baseDir, "4", "train")
-  val omnibusNDDA4Train = omnibusDaDataset(baseDir, "4", "train")
-  val omnibusNDDA4TrainBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
-    omnibusNDDA4TrainFile,
+  val omnibusNdda4TrainFile = omnibusDaFile(baseDir, "4", "train")
+  val omnibusNdda4Train = omnibusDaDataset(baseDir, "4", "train")
+  val omnibusNdda4TrainBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNdda4TrainFile,
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
-  val omnibusNDDA4TrainFileWithBackground: JValue =
+  val omnibusNdda4TrainFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
-    ("sentences" -> omnibusNDDA4TrainFile) ~
-    ("background" -> omnibusNDDA4TrainBuscBackgroundFile)
+    ("sentences" -> omnibusNdda4TrainFile) ~
+    ("background" -> omnibusNdda4TrainBuscBackgroundFile)
 
   // Dev Files
-  val omnibusNDDA4DevFile = omnibusDaFile(baseDir, "4", "dev")
-  val omnibusNDDA4Dev = omnibusDaDataset(baseDir, "4", "dev")
-  val omnibusNDDA4DevBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
-    omnibusNDDA4DevFile,
+  val omnibusNdda4DevFile = omnibusDaFile(baseDir, "4", "dev")
+  val omnibusNdda4Dev = omnibusDaDataset(baseDir, "4", "dev")
+  val omnibusNdda4DevBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNdda4DevFile,
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
-  val omnibusNDDA4DevFileWithBackground: JValue =
+  val omnibusNdda4DevFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
-    ("sentences" -> omnibusNDDA4DevFile) ~
-    ("background" -> omnibusNDDA4DevBuscBackgroundFile)
+    ("sentences" -> omnibusNdda4DevFile) ~
+    ("background" -> omnibusNdda4DevBuscBackgroundFile)
 
   // Test Files
-  val omnibusNDDA4TestFile = omnibusDaFile(baseDir, "4", "test")
-  val omnibusNDDA4Test = omnibusDaDataset(baseDir, "4", "test")
-  val omnibusNDDA4TestBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
-    omnibusNDDA4TestFile,
+  val omnibusNdda4TestFile = omnibusDaFile(baseDir, "4", "test")
+  val omnibusNdda4Test = omnibusDaDataset(baseDir, "4", "test")
+  val omnibusNdda4TestBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNdda4TestFile,
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
-  val omnibusNDDA4TestFileWithBackground: JValue =
+  val omnibusNdda4TestFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
-    ("sentences" -> omnibusNDDA4TestFile) ~
-    ("background" -> omnibusNDDA4TestBuscBackgroundFile)
+    ("sentences" -> omnibusNdda4TestFile) ~
+    ("background" -> omnibusNdda4TestBuscBackgroundFile)
 }

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
@@ -1,0 +1,42 @@
+package org.allenai.deep_qa.experiments.datasets
+
+import org.json4s._
+import org.json4s.JsonDSL._
+
+/**
+ * This object contains a bunch of JValue specifications for the
+ * Omnibus DA dataset's data files.
+ */
+object omnibusDaDatasets {
+
+  def omnibusDaFile(omnibusDaDir: String, grade: String, split: String): JValue = {
+    val datasetGradePath = s"Omnibus-Gr${grade}-NDDA"
+    val outputDirectory = omnibusDaDir + datasetGradePath +"/processed/"
+    val inputFile = omnibusDaDir + datasetGradePath + s"/${datasetGradePath}-${split}.csv"
+    val outputFiles = Seq(outputDirectory + s"${split}.tsv")
+    ("sentence producer type" -> "dataset reader") ~
+      ("reader" -> "omnibus da") ~
+      ("create sentence indices" -> true) ~
+      ("input file" -> inputFile) ~
+      ("output files" -> outputFiles)
+  }
+
+  def omnibusDaDataset(omnibusDaDir: String, grade: String, split: String): JValue = {
+    val file = omnibusDaFile(omnibusDaDir, grade, split)
+    ("data files" -> List(file))
+  }
+
+  val baseDir = "/efs/data/dlfa/omnibus_ndda/"
+  // Train files
+  val omnibusNDDA04TrainFile = omnibusDaFile(baseDir, "04", "train")
+  val omnibusNDDA04Train = omnibusDaDataset(baseDir, "04", "train")
+
+  // Dev Files
+  val omnibusNDDA04DevFile = omnibusDaFile(baseDir, "04", "dev")
+  val omnibusNDDA04Dev = omnibusDaDataset(baseDir, "04", "dev")
+
+  // Test Files
+  val omnibusNDDA04TestFile = omnibusDaFile(baseDir, "04", "test")
+  val omnibusNDDA04Test = omnibusDaDataset(baseDir, "04", "test")
+
+}

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
@@ -7,7 +7,7 @@ import org.json4s.JsonDSL._
  * This object contains a bunch of JValue specifications for the
  * Omnibus DA dataset's data files.
  */
-object omnibusDa {
+object OmnibusDa {
 
   def omnibusDaFile(omnibusDaDir: String, grade: String, split: String): JValue = {
     if (grade.length == 1) {

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
@@ -7,9 +7,15 @@ import org.json4s.JsonDSL._
  * This object contains a bunch of JValue specifications for the
  * Omnibus DA dataset's data files.
  */
-object omnibusDaDatasets {
+object omnibusDa {
 
   def omnibusDaFile(omnibusDaDir: String, grade: String, split: String): JValue = {
+    if (grade.length == 1) {
+      val grade_str = "0" + grade
+    }
+    else{
+      val grade_str = grade
+    }
     val datasetGradePath = s"Omnibus-Gr${grade}-NDDA"
     val outputDirectory = omnibusDaDir + datasetGradePath +s"/processed/${split}/"
     val splitCapitalized = split.capitalize
@@ -29,42 +35,41 @@ object omnibusDaDatasets {
 
   val baseDir = "/efs/data/dlfa/omnibus_ndda/"
   // Train files
-  val omnibusNDDA04TrainFile = omnibusDaFile(baseDir, "04", "train")
-  val omnibusNDDA04Train = omnibusDaDataset(baseDir, "04", "train")
-  val omnibusNDDA04TrainBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
-    omnibusNDDA04TrainFile,
+  val omnibusNDDA4TrainFile = omnibusDaFile(baseDir, "4", "train")
+  val omnibusNDDA4Train = omnibusDaDataset(baseDir, "4", "train")
+  val omnibusNDDA4TrainBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNDDA4TrainFile,
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
-  val omnibusNDDA04TrainFileWithBackground: JValue =
+  val omnibusNDDA4TrainFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
-    ("sentences" -> omnibusNDDA04TrainFile) ~
-    ("background" -> omnibusNDDA04TrainBuscBackgroundFile)
+    ("sentences" -> omnibusNDDA4TrainFile) ~
+    ("background" -> omnibusNDDA4TrainBuscBackgroundFile)
 
   // Dev Files
-  val omnibusNDDA04DevFile = omnibusDaFile(baseDir, "04", "dev")
-  val omnibusNDDA04Dev = omnibusDaDataset(baseDir, "04", "dev")
-  val omnibusNDDA04DevBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
-    omnibusNDDA04DevFile,
+  val omnibusNDDA4DevFile = omnibusDaFile(baseDir, "4", "dev")
+  val omnibusNDDA4Dev = omnibusDaDataset(baseDir, "4", "dev")
+  val omnibusNDDA4DevBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNDDA4DevFile,
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
-  val omnibusNDDA04DevFileWithBackground: JValue =
+  val omnibusNDDA4DevFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
-    ("sentences" -> omnibusNDDA04DevFile) ~
-    ("background" -> omnibusNDDA04DevBuscBackgroundFile)
+    ("sentences" -> omnibusNDDA4DevFile) ~
+    ("background" -> omnibusNDDA4DevBuscBackgroundFile)
 
   // Test Files
-  val omnibusNDDA04TestFile = omnibusDaFile(baseDir, "04", "test")
-  val omnibusNDDA04Test = omnibusDaDataset(baseDir, "04", "test")
-  val omnibusNDDA04TestBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
-    omnibusNDDA04TestFile,
+  val omnibusNDDA4TestFile = omnibusDaFile(baseDir, "4", "test")
+  val omnibusNDDA4Test = omnibusDaDataset(baseDir, "4", "test")
+  val omnibusNDDA4TestBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
+    omnibusNDDA4TestFile,
     "question and answer",
     ScienceCorpora.buscElasticSearchIndex(3)
   )
-  val omnibusNDDA04TestFileWithBackground: JValue =
+  val omnibusNDDA4TestFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
-    ("sentences" -> omnibusNDDA04TestFile) ~
-    ("background" -> omnibusNDDA04TestBuscBackgroundFile)
-
+    ("sentences" -> omnibusNDDA4TestFile) ~
+    ("background" -> omnibusNDDA4TestBuscBackgroundFile)
 }

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/SciQ.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/SciQ.scala
@@ -56,7 +56,7 @@ object SciQDatasets {
     ScienceCorpora.buscElasticSearchIndex(3)
   )
   val readingComprehensionTrainWithBuscBackgroundFile: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> mcTrainFile) ~
       ("background" -> mcTrainBuscBackgroundFile)
 
@@ -66,7 +66,7 @@ object SciQDatasets {
     ScienceCorpora.aristoDefaultElasticSearchIndex(3)
   )
   val readingComprehensionTrainWithLuceneBackgroundFile: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> mcTrainFile) ~
       ("background" -> mcTrainLuceneBackgroundFile)
 
@@ -86,7 +86,7 @@ object SciQDatasets {
     ScienceCorpora.buscElasticSearchIndex(3)
   )
   val readingComprehensionDevWithBuscBackgroundFile: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> mcDevFile) ~
       ("background" -> mcDevBuscBackgroundFile)
 
@@ -96,7 +96,7 @@ object SciQDatasets {
     ScienceCorpora.aristoDefaultElasticSearchIndex(3)
   )
   val readingComprehensionDevWithLuceneBackgroundFile: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> mcDevFile) ~
       ("background" -> mcDevLuceneBackgroundFile)
 
@@ -115,7 +115,7 @@ object SciQDatasets {
     ScienceCorpora.buscElasticSearchIndex(3)
   )
   val readingComprehensionTestWithBuscBackgroundFile: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> mcTestFile) ~
       ("background" -> mcTestBuscBackgroundFile)
 
@@ -125,7 +125,7 @@ object SciQDatasets {
     ScienceCorpora.aristoDefaultElasticSearchIndex(3)
   )
   val readingComprehensionTestWithLuceneBackgroundFile: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> mcTestFile) ~
       ("background" -> mcTestLuceneBackgroundFile)
 

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/Science.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/Science.scala
@@ -197,17 +197,17 @@ object ScienceDatasets {
    */
 
   val omnibusRcGradeFourTrainQuestionsWithBuscBackground: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> ScienceFiles.omnibusGradeFourTrainSentences_questionAndAnswer) ~
       ("background" -> omnibusQaGradeFourTrainBuscBackgroundFile)
 
   val omnibusRcGradeFourDevQuestionsWithBuscBackground: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> ScienceFiles.omnibusGradeFourDevSentences_questionAndAnswer) ~
       ("background" -> omnibusQaGradeFourDevBuscBackgroundFile)
 
   val omnibusRcGradeFourTestQuestionsWithBuscBackground: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> ScienceFiles.omnibusGradeFourTestSentences_questionAndAnswer) ~
       ("background" -> omnibusQaGradeFourTestBuscBackgroundFile)
 
@@ -272,17 +272,17 @@ object ScienceDatasets {
    */
 
   val omnibusRcGradeEightTrainQuestionsWithBuscBackground: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> ScienceFiles.omnibusGradeEightTrainSentences_questionAndAnswer) ~
       ("background" -> omnibusQaGradeEightTrainBuscBackgroundFile)
 
   val omnibusRcGradeEightDevQuestionsWithBuscBackground: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> ScienceFiles.omnibusGradeEightDevSentences_questionAndAnswer) ~
       ("background" -> omnibusQaGradeEightDevBuscBackgroundFile)
 
   val omnibusRcGradeEightTestQuestionsWithBuscBackground: JValue =
-    ("sentence producer type" -> "qa and background to rc") ~
+    ("sentence producer type" -> "combine background and instance") ~
       ("sentences" -> ScienceFiles.omnibusGradeEightTestSentences_questionAndAnswer) ~
       ("background" -> omnibusQaGradeEightTestBuscBackgroundFile)
 

--- a/src/main/scala/org/allenai/deep_qa/pipeline/CombineInstanceBackgroundStep.scala
+++ b/src/main/scala/org/allenai/deep_qa/pipeline/CombineInstanceBackgroundStep.scala
@@ -12,22 +12,23 @@ import scala.sys.process.Process
 import scala.sys.process.ProcessLogger
 
 /**
-  * This Step is a SentenceProducer that combines a QuestionAnswerInstance
+  * This Step is a SentenceProducer that combines an Instance
   * with background sentences from a BackgroundCorpusSearcher.
-  * The QuestionAnswerInstance input file has the format
-  * "[index][tab][question][tab][options][tab][label]", and the file with
+  * The Instance input file has the format
+  * "[index][tab][question]...", and the file with
   * background sentences has the format
   * "[index][tab][background1][tab][background2][tab]...". The output file
-  * is in the format of a MCReadingComprehensionInstance with
-  * "[passage][tab][question][tab][options][tab][label]".
-  * The background sentences compose the passage in this case.
+  * simply adds the background sentences to the start of each line.
+  * For example, if the Instance input file has format
+  * [index][tab][question][tab][options], this will output
+  * [background_sentences][tab][question][tab][options].
  */
-class QaBackgroundToRcStep(
+class CombineInstanceBackgroundStep(
   val params: JValue,
   val fileUtil: FileUtil
 ) extends Step(Some(params), fileUtil) with SentenceProducer {
   implicit val formats = DefaultFormats
-  override val name = "QA Background To MC Step"
+  override val name = "Combine Instance and Background Step"
 
   val validParams = baseParams ++ Seq("sentences", "background", "output file")
   JsonHelper.ensureNoExtras(params, name, validParams)

--- a/src/main/scala/org/allenai/deep_qa/pipeline/SentenceProducer.scala
+++ b/src/main/scala/org/allenai/deep_qa/pipeline/SentenceProducer.scala
@@ -71,7 +71,7 @@ object SentenceProducer {
       // which SentenceProducer is a subclass...
       case JString("sentence to tuple") => new SentenceToTuple(params, fileUtil)
       case JString("drop first column") => new DropFirstColumnStep(params, fileUtil)
-      case JString("qa and background to rc") => new QaBackgroundToRcStep(params, fileUtil)
+      case JString("combine background and instance") => new CombineInstanceBackgroundStep(params, fileUtil)
       case jval => throw new IllegalStateException(s"unrecognized SentenceProducer parameters: $jval")
     }
   }

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -9,33 +9,33 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
   val questionText1 = "Coal is a nonrenewable energy resource. Identify the original "+
     "source of the energy stored in coal."
   val answerText1 = "The Sun is the original source of energy."
-  val header = "\"id\",\"parentId\",\"isArchived\",\"questionText\"," +
-    "\"answerText\",\"points\",\"isTest\",\"isMultipleChoice\",\"hasDiagram\"," +
-    "\"examName\",\"examGrade\",\"examYear\",\"notes\",\"tags\",\"legacyId\"," +
-    "\"importedQuestionId\""
+  val header = """"id","parentId","isArchived","questionText",""" +
+    """"answerText","points","isTest","isMultipleChoice","hasDiagram",""" +
+    """"examName","examGrade","examYear","notes","tags","legacyId",""" +
+    """importedQuestionId"""
 
-  val row1 = "\"1\",,\"false\",\"" + s"${questionText1}" + "\",\"" + s"${answerText1}" + "\"," +
-    "\"1\",\"false\",\"false\",\"false\",\"Source1\",\"5\",\"2015\",\"\",\"Tag1\"," +
-    "\"legacyId1\",\"importedId1\""
+  val row1 = """"1",,"false","""" + s"${questionText1}" + """","""" + s"${answerText1}" + """",""" +
+    """"1","false","false","false","Source1","5","2015","","Tag1",""" +
+    """"legacyId1","importedId1""""
 
   val questionText2 = "Coal is a nonrenewable energy resource. People burn coal to " +
     "make electricity and heat buildings. Explain how long it would most likely take for new coal " +
     "to form."
   val answerText2 = "Coal may slowly form over millions of years."
-  val row2 = "\"1\",,\"false\",\"" + s"${questionText2}"+"\",\"" + s"${answerText2}" + "\"," +
-    "\"1\",\"false\",\"false\",\"false\",\"Source2\",\"5\",\"2015\",\"\",\"Tag2\"," +
-    "\"legacyId2\",\"importedId2\""
+  val row2 = """"1",,"false","""" + s"${questionText2}"+"""","""" + s"${answerText2}" + """",""" +
+    """"1","false","false","false","Source2","5","2015","","Tag2",""" +
+    """"legacyId2","importedId2""""
 
 
   val datasetFile = "./dataset"
   val datasetFileContents = s"""${header}
       |${row1}
-      |${row2}"""".stripMargin
+      |${row2}""".stripMargin
 
-  fileUtil.mkdirsForFile(datasetFile)
-  fileUtil.writeContentsToFile(datasetFile, datasetFileContents)
   val reader = new OmnibusDaDatasetReader(fileUtil)
   "readFile" should "return a correct dataset" in {
+    fileUtil.mkdirsForFile(datasetFile)
+    fileUtil.writeContentsToFile(datasetFile, datasetFileContents)
     val dataset = reader.readFile(datasetFile)
     fileUtil.deleteFile(datasetFile)
 

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -14,7 +14,7 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     """"examName","examGrade","examYear","notes","tags","legacyId",""" +
     """importedQuestionId"""
 
-  val row1 = """"1",,"false","""" + s"${questionText1}" + """","""" + s"${answerText1}" + """",""" +
+  val row1 = s""""1",,"false","${questionText1}","${answerText1}",""" +
     """"1","false","false","false","Source1","5","2015","","Tag1",""" +
     """"legacyId1","importedId1""""
 
@@ -22,7 +22,7 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     "make electricity and heat buildings. Explain how long it would most likely take for new coal " +
     "to form."
   val answerText2 = "Coal may slowly form over millions of years."
-  val row2 = """"1",,"false","""" + s"${questionText2}"+"""","""" + s"${answerText2}" + """",""" +
+  val row2 = s""""1",,"false","${questionText2}","${answerText2}",""" +
     """"1","false","false","false","Source2","5","2015","","Tag2",""" +
     """"legacyId2","importedId2""""
 

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -32,7 +32,7 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
       |${row1}
       |${row2}""".stripMargin
 
-  val reader = new OmnibusDaDatasetReader(fileUtil)
+  val reader = new OmnibusDaDatasetReader()
   "readFile" should "return a correct dataset" in {
     fileUtil.mkdirsForFile(datasetFile)
     fileUtil.writeContentsToFile(datasetFile, datasetFileContents)

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -1,0 +1,46 @@
+package org.allenai.deep_qa.data
+
+import com.mattg.util.FileUtil
+import org.scalatest._
+
+class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
+
+  val fileUtil = new FileUtil
+  val questionText1 = "Coal is a nonrenewable energy resource. Identify the original "+
+    "source of the energy stored in coal."
+  val answerText1 = "The Sun is the original source of energy."
+  val header = "\"id\",\"parentId\",\"isArchived\",\"questionText\"," +
+    "\"answerText\",\"points\",\"isTest\",\"isMultipleChoice\",\"hasDiagram\"," +
+    "\"examName\",\"examGrade\",\"examYear\",\"notes\",\"tags\",\"legacyId\"," +
+    "\"importedQuestionId\""
+
+  val row1 = "\"1\",,\"false\",\"" + s"${questionText1}" + "\",\"" + s"${answerText1}" + "\"," +
+    "\"1\",\"false\",\"false\",\"false\",\"Source1\",\"5\",\"2015\",\"\",\"Tag1\"," +
+    "\"legacyId1\",\"importedId1\""
+
+  val questionText2 = "Coal is a nonrenewable energy resource. People burn coal to " +
+    "make electricity and heat buildings. Explain how long it would most likely take for new coal " +
+    "to form."
+  val answerText2 = "Coal may slowly form over millions of years."
+  val row2 = "\"1\",,\"false\",\"" + s"${questionText2}"+"\",\"" + s"${answerText2}" + "\"," +
+    "\"1\",\"false\",\"false\",\"false\",\"Source2\",\"5\",\"2015\",\"\",\"Tag2\"," +
+    "\"legacyId2\",\"importedId2\""
+
+
+  val datasetFile = "./dataset"
+  val datasetFileContents = s"""${header}
+      |${row1}
+      |${row2}"""".stripMargin
+
+  fileUtil.mkdirsForFile(datasetFile)
+  fileUtil.writeContentsToFile(datasetFile, datasetFileContents)
+  val reader = new OmnibusDaDatasetReader(fileUtil)
+  "readFile" should "return a correct dataset" in {
+    val dataset = reader.readFile(datasetFile)
+    fileUtil.deleteFile(datasetFile)
+
+    dataset.instances.size should be(2)
+    dataset.instances(0) should be(DirectAnswerInstance(questionText1, Some(answerText1)))
+    dataset.instances(1) should be(DirectAnswerInstance(questionText2, Some(answerText2)))
+  }
+}


### PR DESCRIPTION
This reader reads the raw Omnibus 4 NDDA dataset (haven't gotten my hands on 8 yet, but I expect no code changes should be necessary) and stores them as `DirectAnswerInstances`. Next, i'm hoping to use the `BackgroundCorpusSearcher` to add the appropriate background sentences to this dataset for use in span prediction.