### PR TITLE
fetch background sentences from paragraph indexed corpora for OmnibusDA

### DIFF
--- a/src/main/scala/org/allenai/deep_qa/data/BackgroundCorpusSearcher.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/BackgroundCorpusSearcher.scala
@@ -50,6 +50,7 @@ class LuceneBackgroundCorpusSearcher(params: JValue) extends BackgroundCorpusSea
     "remove query near duplicates",
     "elastic search index url",
     "elastic search index name",
+    "elastic search index type",
     "elastic search cluster name",
     "elastic search index port"
   )
@@ -77,6 +78,7 @@ class LuceneBackgroundCorpusSearcher(params: JValue) extends BackgroundCorpusSea
   val esPort = JsonHelper.extractWithDefault(params, "elastic search index port", 9300)
   val esClusterName = JsonHelper.extractWithDefault(params, "elastic search cluster name", "aristo-es")
   val esIndexName = JsonHelper.extractWithDefault(params, "elastic search index name", Seq("busc"))
+  val esIndexType = JsonHelper.extractWithDefault(params, "elastic search index type", "sentence")
 
   lazy val address = new InetSocketTransportAddress(new InetSocketAddress(esUrl, esPort))
   lazy val settings = Settings.builder().put("cluster.name", esClusterName).build()
@@ -101,7 +103,7 @@ class LuceneBackgroundCorpusSearcher(params: JValue) extends BackgroundCorpusSea
     }
     //Perform the search
     val response = esClient.prepareSearch(esIndexName.toSeq: _*)
-        .setTypes("sentence")
+        .setTypes(esIndexType)
         .setQuery(queryBuilder)
         .setFrom(0).setSize(numPassagesPerQuery * hitMultiplier).setExplain(true)
         .execute()

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/OmnibusDa.scala
@@ -45,7 +45,7 @@ object OmnibusDa {
   val omnibusNdda4TrainBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
     omnibusNdda4TrainFile,
     "question and answer",
-    ScienceCorpora.buscElasticSearchIndex(3)
+    ScienceCorpora.buscElasticSearchIndex(3, "paragraph")
   )
   val omnibusNdda4TrainFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
@@ -58,7 +58,7 @@ object OmnibusDa {
   val omnibusNdda4DevBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
     omnibusNdda4DevFile,
     "question and answer",
-    ScienceCorpora.buscElasticSearchIndex(3)
+    ScienceCorpora.buscElasticSearchIndex(3, "paragraph")
   )
   val omnibusNdda4DevFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
@@ -71,7 +71,7 @@ object OmnibusDa {
   val omnibusNdda4TestBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
     omnibusNdda4TestFile,
     "question and answer",
-    ScienceCorpora.buscElasticSearchIndex(3)
+    ScienceCorpora.buscElasticSearchIndex(3, "paragraph")
   )
   val omnibusNdda4TestFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
@@ -87,7 +87,7 @@ object OmnibusDa {
   val omnibusNdda8TrainBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
     omnibusNdda8TrainFile,
     "question and answer",
-    ScienceCorpora.buscElasticSearchIndex(3)
+    ScienceCorpora.buscElasticSearchIndex(3, "paragraph")
   )
   val omnibusNdda8TrainFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
@@ -100,7 +100,7 @@ object OmnibusDa {
   val omnibusNdda8DevBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
     omnibusNdda8DevFile,
     "question and answer",
-    ScienceCorpora.buscElasticSearchIndex(3)
+    ScienceCorpora.buscElasticSearchIndex(3, "paragraph")
   )
   val omnibusNdda8DevFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~
@@ -113,7 +113,7 @@ object OmnibusDa {
   val omnibusNdda8TestBuscBackgroundFile = SciQDatasets.makePassageBackgroundFile(
     omnibusNdda8TestFile,
     "question and answer",
-    ScienceCorpora.buscElasticSearchIndex(3)
+    ScienceCorpora.buscElasticSearchIndex(3, "paragraph")
   )
   val omnibusNdda8TestFileWithBackground: JValue =
     ("sentence producer type" -> "combine background and instance") ~

--- a/src/main/scala/org/allenai/deep_qa/experiments/datasets/Science.scala
+++ b/src/main/scala/org/allenai/deep_qa/experiments/datasets/Science.scala
@@ -578,8 +578,12 @@ object ScienceFiles {
  * These are corpora that can be used for searching, or for training language models, or the like.
  */
 object ScienceCorpora {
-  def buscElasticSearchIndex(numResults: Int): JValue =
+  def buscElasticSearchIndex(
+    numResults: Int,
+    elasticSearchIndexType: String="sentence"
+  ): JValue =
     ("num passages per query" -> numResults) ~
+      ("elastic search index type" -> elasticSearchIndexType) ~
       ("elastic search index url" -> "aristo-es1.dev.ai2") ~
       ("elastic search index port" -> 9300) ~
       ("elastic search cluster name" -> "aristo-es") ~


### PR DESCRIPTION
This file adds the functionality for selecting the index type for ElasticSearch, and also modifies the default searcher used in OmnibusDA to use paragraph indexed corpora.