### PR TITLE
add method to convert imperative questions to interrogative questions

### DIFF
--- a/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
@@ -8,6 +8,7 @@ import com.mattg.util.FileUtil
 import java.io.StringReader
 import org.json4s._
 import org.json4s.native.JsonMethods.parse
+import org.allenai.deep_qa.parse.Parser
 
 /*
  * Read an Omnibus direct answer file pulled from the Aristo
@@ -28,5 +29,48 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
       DirectAnswerInstance(questionText, Some(answerText))
     }}
     Dataset(instances)
+  }
+
+  def imperativeToInterrogative(inputImperative: String): String = {
+    val imperativeSentences = Parser.stanford.splitSentences(inputImperative)
+    val imperatives = """identify|name|define|give|explain|describe|list"""
+    val interrogatives = """who|what|when|where|why|how"""
+
+    val imperativeModifierRemovedSentences = for {
+      imperativeSentence <- imperativeSentences
+
+      // If there is an imperative, remove all words that occur before
+      // it (the first imperative) in the sentence. Thus, "Please briefly explain this." becomes
+      // "explain this."
+      imperativeModifiers = s"""(?i).+?(?=(${imperatives}) )""".r
+      imperativeModifierRemovedSentence = imperativeModifiers.replaceFirstIn(imperativeSentence, "")
+    } yield imperativeModifierRemovedSentence
+    // For each sentence, the imperative words will be replaced with "What is" if
+    // they occur at the start of the sentence. However, if these
+    // imperative words occur directly before the the interrogative words, we just
+    // delete the imperative words.
+    val imperativesBeforeInterrogatives = s"""(?i)^((${imperatives})+) (?=${interrogatives})""".r
+    val generalImperatives = s"""(?i)^((${imperatives})+)""".r
+
+    val transformedImperativeSentences = for {
+      imperativeSentence <- imperativeModifierRemovedSentences
+      // First, if imperative words occur before interrogative words, delete the imperative
+      imperativeSentenceNoImperativesBeforeInterrogatives = imperativesBeforeInterrogatives.replaceFirstIn(
+        imperativeSentence,
+        ""
+      )
+
+      // If the imperative words are still there, it means that they didn't occur
+      // before interrogative words and thus we can replace them with "what is"
+      interrogativeSentence = generalImperatives.replaceFirstIn(
+        imperativeSentenceNoImperativesBeforeInterrogatives,
+        "what is"
+      )
+
+      // now, strip the excess whitespace on both sides and capitalize
+      cleanedInterrogativeSentence = interrogativeSentence.trim.capitalize
+    } yield cleanedInterrogativeSentence
+    val transformedImperativePassage = transformedImperativeSentences.mkString(" ")
+    return transformedImperativePassage
   }
 }

--- a/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
@@ -47,7 +47,7 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
     } yield imperativeModifierRemovedSentence
     // For each sentence, the imperative words will be replaced with "What is" if
     // they occur at the start of the sentence. However, if these
-    // imperative words occur directly before the the interrogative words, we just
+    // imperative words occur directly before the interrogative words, we just
     // delete the imperative words.
     val imperativesBeforeInterrogatives = s"""(?i)^((${imperatives})+) (?=${interrogatives})""".r
     val generalImperatives = s"""(?i)^((${imperatives})+)""".r

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -6,8 +6,10 @@ import org.scalatest._
 class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
 
   val fileUtil = new FileUtil
-  val questionText1 = "Coal is a nonrenewable energy resource. Identify the original "+
+  val questionText1 = "Coal is a nonrenewable energy resource. Identify the original " +
     "source of the energy stored in coal."
+  val transformedQuestionText1 = "Coal is a nonrenewable energy resource. What is the " +
+  "original source of the energy stored in coal."
   val answerText1 = "The Sun is the original source of energy."
   val header = """"id","parentId","isArchived","questionText",""" +
     """"answerText","points","isTest","isMultipleChoice","hasDiagram",""" +
@@ -21,11 +23,54 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
   val questionText2 = "Coal is a nonrenewable energy resource. People burn coal to " +
     "make electricity and heat buildings. Explain how long it would most likely take for new coal " +
     "to form."
+  val transformedQuestionText2 = "Coal is a nonrenewable energy resource. People burn coal to " +
+    "make electricity and heat buildings. How long it would most likely take for new coal to form."
   val answerText2 = "Coal may slowly form over millions of years."
   val row2 = s""""1",,"false","${questionText2}","${answerText2}",""" +
     """"1","false","false","false","Source2","5","2015","","Tag2",""" +
     """"legacyId2","importedId2""""
 
+  val questionText3 = "Read the given statement and determine if the behavior is "+
+    "either learned or innate. A bear eating salmon caught from a river."
+  val transformedQuestionText3 = "Read the given statement and determine if the "+
+    "behavior is either learned or innate. A bear eating salmon caught from a river."
+
+  val questionText4 = "Even though an adult amphibian can live on land, why must it " +
+    "return to the water? (Explain.)"
+  val transformedQuestionText4 = "Even though an adult amphibian can live on land, " +
+    "why must it return to the water? (Explain.)"
+
+  // TODO(nelson): Would like to be able to handle plural/singular.
+  val questionText5 = "Name four organisms you might find living in or around a " +
+    "freshwater lake."
+  val transformedQuestionText5 = "What is four organisms you might find living in or around a " +
+  "freshwater lake."
+  val questionText6 = "List the conditions that must be present in order for a " +
+  "seed to germinate."
+  val transformedQuestionText6 = "What is the conditions that must be present in "+
+  "order for a seed to germinate."
+
+  // TODO(nelson): not clear how to insert the proper verbs here.
+  val questionText7 = "Briefly explain why most animal life on Earth could not survive without plants."
+  val transformedQuestionText7 = "Why most animal life on Earth could not survive without plants."
+
+  val questionText8 = "The earthworm has no lungs and breathes in oxygen through " +
+    "its moist skin. If its skin dries out, the worm will suffocate. " +
+    "Mucus-producing cells also cover its skin. Not only does the mucus help keep "+
+    "the body moist, but it also makes the worm's body slippery to help it move "+
+    "through the soil. In addition, the worm's mucus-covered skin helps prevent "+
+    "collapsing of the tunnel walls by packing the soil particles together. In your "+
+    "own words, explain how the earthworms described in the reading passage breathe."
+  val transformedQuestionText8 = "The earthworm has no lungs and breathes in oxygen "+
+    "through its moist skin. If its skin dries out, the worm will suffocate. " +
+    "Mucus-producing cells also cover its skin. Not only does the mucus help keep "+
+    "the body moist, but it also makes the worm's body slippery to help it move "+
+    "through the soil. In addition, the worm's mucus-covered skin helps prevent "+
+    "collapsing of the tunnel walls by packing the soil particles together. "+
+    "How the earthworms described in the reading passage breathe."
+
+  val questionText9 = "Explain how the sun provides energy to ecosystems."
+  val transformedQuestionText9 = "How the sun provides energy to ecosystems."
 
   val datasetFile = "./dataset"
   val datasetFileContents = s"""${header}
@@ -42,5 +87,16 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     dataset.instances.size should be(2)
     dataset.instances(0) should be(DirectAnswerInstance(questionText1, Some(answerText1)))
     dataset.instances(1) should be(DirectAnswerInstance(questionText2, Some(answerText2)))
+  }
+  "imperativeToInterrogative" should "return an imperative question converted to interrogative" in {
+    reader.imperativeToInterrogative(questionText1) should be (transformedQuestionText1)
+    reader.imperativeToInterrogative(questionText2) should be (transformedQuestionText2)
+    reader.imperativeToInterrogative(questionText3) should be (transformedQuestionText3)
+    reader.imperativeToInterrogative(questionText4) should be (transformedQuestionText4)
+    reader.imperativeToInterrogative(questionText5) should be (transformedQuestionText5)
+    reader.imperativeToInterrogative(questionText6) should be (transformedQuestionText6)
+    reader.imperativeToInterrogative(questionText7) should be (transformedQuestionText7)
+    reader.imperativeToInterrogative(questionText8) should be (transformedQuestionText8)
+    reader.imperativeToInterrogative(questionText9) should be (transformedQuestionText9)
   }
 }


### PR DESCRIPTION
I wrote a function that converts questions typically found in science exams (e.g. "Explain this", "Describe that", "Name these") to questions that are more squad-like. The tests might be good examples for what behavior it does specifically --- I also tried to comment inline heavily to reduce confusion later down the line as the regex can be pretty inscrutable.