### PR TITLE
Question Transformation Enhancements

### DIFF
--- a/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
@@ -44,10 +44,13 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
 
       // If there is an imperative, remove all words that occur before
       // it (the first imperative) in the sentence. Thus, "Please briefly explain this." becomes
-      // "explain this."
+      // "explain this.". However, if the first word is an imperative or an interrogative word,
+      // do not remove anything.
       imperativeModifiers = s"""(?i).+?(?=(${imperativesStr}) )""".r
       imperativeModifierRemovedSentence = if (interrogatives.contains(
-        imperativeSentence.toLowerCase.split(" ").head)
+        imperativeSentence.toLowerCase.split(" ").head) ||
+        imperatives.contains(
+          imperativeSentence.toLowerCase.split(" ").head)
       ) {
         imperativeSentence
       }

--- a/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
@@ -33,10 +33,10 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
 
   def imperativeToInterrogative(inputImperative: String): String = {
     val imperativeSentences = Parser.stanford.splitSentences(inputImperative)
-    val interrogatives = Seq("who", "what", "when", "where", "why", "how")
+    val interrogatives = Set("who", "what", "when", "where", "why", "how")
     val interrogativesStr = interrogatives.mkString("|")
 
-    val imperatives = Seq("identify", "name", "define", "give", "explain", "describe", "list")
+    val imperatives = Set("identify", "name", "define", "give", "explain", "describe", "list")
     val imperativesStr = imperatives.mkString("|")
 
     val imperativeModifierRemovedSentences = for {
@@ -47,14 +47,12 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
       // "explain this.". However, if the first word is an imperative or an interrogative word,
       // do not remove anything.
       imperativeModifiers = s"""(?i).+?(?=(${imperativesStr}) )""".r
-      imperativeModifierRemovedSentence = if (interrogatives.contains(
-        imperativeSentence.toLowerCase.split(" ").head) ||
-        imperatives.contains(
-          imperativeSentence.toLowerCase.split(" ").head)
-      ) {
+      firstWord = imperativeSentence.toLowerCase.split(" ").head
+
+      imperativeModifierRemovedSentence = if (interrogatives.contains(firstWord) || imperatives.contains(firstWord)) {
         imperativeSentence
       }
-      else{
+      else {
         imperativeModifiers.replaceFirstIn(
           imperativeSentence.toLowerCase,
           ""
@@ -85,7 +83,7 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
       questionVerb = if (nnsIndex == -1 || (nnIndex < nnsIndex && nnIndex != -1)){
         "is"
       }
-      else{
+      else {
         "are"
       }
       // If the imperative words are still there, it means that they didn't occur

--- a/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReader.scala
@@ -26,7 +26,7 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
       answerText = line(4)
     } yield (questionText, answerText)
     val instances = instanceTuples.map { case (questionText, answerText) => {
-      DirectAnswerInstance(questionText, Some(answerText))
+      DirectAnswerInstance(imperativeToInterrogative(questionText), Some(answerText))
     }}
     Dataset(instances)
   }
@@ -62,10 +62,15 @@ class OmnibusDaDatasetReader extends DatasetReader[DirectAnswerInstance] {
 
       // If the imperative words are still there, it means that they didn't occur
       // before interrogative words and thus we can replace them with "what is"
-      interrogativeSentence = generalImperatives.replaceFirstIn(
+      convertedSentence = generalImperatives.replaceFirstIn(
         imperativeSentenceNoImperativesBeforeInterrogatives,
         "what is"
       )
+      interrogativeSentence = if (convertedSentence != imperativeSentence) {
+        convertedSentence.dropRight(1) + "?"
+      } else {
+        convertedSentence
+      }
 
       // now, strip the excess whitespace on both sides and capitalize
       cleanedInterrogativeSentence = interrogativeSentence.trim.capitalize

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -83,6 +83,17 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
   val transformedQuestionText11 = "What is another name for the " +
     "\"bristles\" mentioned in the reading passage?"
 
+  val questionText12 = "Describe a plant that is adapted to live in a hot desert, and explain "+
+    "what features make the plant suited to the conditions of this biome."
+  val transformedQuestionText12 = "What is a plant that is adapted to live in a hot desert, and " +
+  "explain what features make the plant suited to the conditions of this biome?"
+
+  val questionText13 = "Please describe a plant that is adapted to live in a hot desert, and explain "+
+  "what features make the plant suited to the conditions of this biome."
+  val transformedQuestionText13 = "What is a plant that is adapted to live in a hot desert, and " +
+  "explain what features make the plant suited to the conditions of this biome?"
+
+
   val datasetFile = "./dataset"
   val datasetFileContents = s"""${header}
       |${row1}
@@ -111,5 +122,7 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     reader.imperativeToInterrogative(questionText9) should be (transformedQuestionText9)
     reader.imperativeToInterrogative(questionText10) should be (transformedQuestionText10)
     reader.imperativeToInterrogative(questionText11) should be (transformedQuestionText11)
+    reader.imperativeToInterrogative(questionText12) should be (transformedQuestionText12)
+    reader.imperativeToInterrogative(questionText12) should be (transformedQuestionText13)
   }
 }

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -36,22 +36,23 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
 
   val questionText4 = "Even though an adult amphibian can live on land, why must it " +
     "return to the water? (Explain.)"
+  // TODO(nelson): Fix this to preserve case.
   val transformedQuestionText4 = "Even though an adult amphibian can live on land, " +
-    "why must it return to the water? (Explain.)"
+    "why must it return to the water? (explain.)"
 
   // TODO(nelson): Would like to be able to handle plural/singular.
   val questionText5 = "Name four organisms you might find living in or around a " +
     "freshwater lake."
-  val transformedQuestionText5 = "What is four organisms you might find living in or around a " +
+  val transformedQuestionText5 = "What are four organisms you might find living in or around a " +
   "freshwater lake?"
   val questionText6 = "List the conditions that must be present in order for a " +
   "seed to germinate."
-  val transformedQuestionText6 = "What is the conditions that must be present in "+
+  val transformedQuestionText6 = "What are the conditions that must be present in "+
   "order for a seed to germinate?"
 
   // TODO(nelson): not clear how to insert the proper verbs here.
   val questionText7 = "Briefly explain why most animal life on Earth could not survive without plants."
-  val transformedQuestionText7 = "Why most animal life on Earth could not survive without plants?"
+  val transformedQuestionText7 = "Why most animal life on earth could not survive without plants?"
 
   val questionText8 = "The earthworm has no lungs and breathes in oxygen through " +
     "its moist skin. If its skin dries out, the worm will suffocate. " +
@@ -70,6 +71,12 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
 
   val questionText9 = "Explain how the sun provides energy to ecosystems."
   val transformedQuestionText9 = "How the sun provides energy to ecosystems?"
+
+  // Test that non-greedy imperative match works as expected.
+  val questionText10 = "Name two examples of habitats, and one organism that would live in " +
+    "each habitat."
+  val transformedQuestionText10 = "What are two examples of habitats, and one organism that would " +
+    "live in each habitat?"
 
   val datasetFile = "./dataset"
   val datasetFileContents = s"""${header}
@@ -97,5 +104,6 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     reader.imperativeToInterrogative(questionText7) should be (transformedQuestionText7)
     reader.imperativeToInterrogative(questionText8) should be (transformedQuestionText8)
     reader.imperativeToInterrogative(questionText9) should be (transformedQuestionText9)
+    reader.imperativeToInterrogative(questionText10) should be (transformedQuestionText10)
   }
 }

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -9,13 +9,12 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
   val questionText1 = "Coal is a nonrenewable energy resource. Identify the original " +
     "source of the energy stored in coal."
   val transformedQuestionText1 = "Coal is a nonrenewable energy resource. What is the " +
-  "original source of the energy stored in coal."
+  "original source of the energy stored in coal?"
   val answerText1 = "The Sun is the original source of energy."
   val header = """"id","parentId","isArchived","questionText",""" +
     """"answerText","points","isTest","isMultipleChoice","hasDiagram",""" +
     """"examName","examGrade","examYear","notes","tags","legacyId",""" +
     """importedQuestionId"""
-
   val row1 = s""""1",,"false","${questionText1}","${answerText1}",""" +
     """"1","false","false","false","Source1","5","2015","","Tag1",""" +
     """"legacyId1","importedId1""""
@@ -24,7 +23,7 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     "make electricity and heat buildings. Explain how long it would most likely take for new coal " +
     "to form."
   val transformedQuestionText2 = "Coal is a nonrenewable energy resource. People burn coal to " +
-    "make electricity and heat buildings. How long it would most likely take for new coal to form."
+    "make electricity and heat buildings. How long it would most likely take for new coal to form?"
   val answerText2 = "Coal may slowly form over millions of years."
   val row2 = s""""1",,"false","${questionText2}","${answerText2}",""" +
     """"1","false","false","false","Source2","5","2015","","Tag2",""" +
@@ -44,15 +43,15 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
   val questionText5 = "Name four organisms you might find living in or around a " +
     "freshwater lake."
   val transformedQuestionText5 = "What is four organisms you might find living in or around a " +
-  "freshwater lake."
+  "freshwater lake?"
   val questionText6 = "List the conditions that must be present in order for a " +
   "seed to germinate."
   val transformedQuestionText6 = "What is the conditions that must be present in "+
-  "order for a seed to germinate."
+  "order for a seed to germinate?"
 
   // TODO(nelson): not clear how to insert the proper verbs here.
   val questionText7 = "Briefly explain why most animal life on Earth could not survive without plants."
-  val transformedQuestionText7 = "Why most animal life on Earth could not survive without plants."
+  val transformedQuestionText7 = "Why most animal life on Earth could not survive without plants?"
 
   val questionText8 = "The earthworm has no lungs and breathes in oxygen through " +
     "its moist skin. If its skin dries out, the worm will suffocate. " +
@@ -67,10 +66,10 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     "the body moist, but it also makes the worm's body slippery to help it move "+
     "through the soil. In addition, the worm's mucus-covered skin helps prevent "+
     "collapsing of the tunnel walls by packing the soil particles together. "+
-    "How the earthworms described in the reading passage breathe."
+    "How the earthworms described in the reading passage breathe?"
 
   val questionText9 = "Explain how the sun provides energy to ecosystems."
-  val transformedQuestionText9 = "How the sun provides energy to ecosystems."
+  val transformedQuestionText9 = "How the sun provides energy to ecosystems?"
 
   val datasetFile = "./dataset"
   val datasetFileContents = s"""${header}
@@ -85,8 +84,8 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     fileUtil.deleteFile(datasetFile)
 
     dataset.instances.size should be(2)
-    dataset.instances(0) should be(DirectAnswerInstance(questionText1, Some(answerText1)))
-    dataset.instances(1) should be(DirectAnswerInstance(questionText2, Some(answerText2)))
+    dataset.instances(0) should be(DirectAnswerInstance(transformedQuestionText1, Some(answerText1)))
+    dataset.instances(1) should be(DirectAnswerInstance(transformedQuestionText2, Some(answerText2)))
   }
   "imperativeToInterrogative" should "return an imperative question converted to interrogative" in {
     reader.imperativeToInterrogative(questionText1) should be (transformedQuestionText1)

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -78,6 +78,12 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
   val transformedQuestionText10 = "What are two examples of habitats, and one organism that would " +
     "live in each habitat?"
 
+  val questionText11 = "What is another name for the \"bristles\" " +
+    "mentioned in the reading passage?"
+
+  val transformedQuestionText11 = "What is another name for the " +
+    "\"bristles\" mentioned in the reading passage?"
+
   val datasetFile = "./dataset"
   val datasetFileContents = s"""${header}
       |${row1}
@@ -105,5 +111,6 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
     reader.imperativeToInterrogative(questionText8) should be (transformedQuestionText8)
     reader.imperativeToInterrogative(questionText9) should be (transformedQuestionText9)
     reader.imperativeToInterrogative(questionText10) should be (transformedQuestionText10)
+    reader.imperativeToInterrogative(questionText11) should be (transformedQuestionText11)
   }
 }

--- a/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/OmnibusDaDatasetReaderSpec.scala
@@ -40,7 +40,6 @@ class OmnibusDaDatasetReaderSpec extends FlatSpecLike with Matchers {
   val transformedQuestionText4 = "Even though an adult amphibian can live on land, " +
     "why must it return to the water? (explain.)"
 
-  // TODO(nelson): Would like to be able to handle plural/singular.
   val questionText5 = "Name four organisms you might find living in or around a " +
     "freshwater lake."
   val transformedQuestionText5 = "What are four organisms you might find living in or around a " +


### PR DESCRIPTION
This PR actually applies the question transformation function, and it adds `?` to the converted questions.

It'd be nice to make this a bit more sophisticated to handle subject-verb agreement. For example the question `Name 5 animals that are classified in phylum mollusca` is currently converted to `What is 5 animals that are classified into phylum mollusca` --- it'd be nice to have this become `What are 5 animals that are classified into phylum mollusca?`, perhaps with some dependency parsing and regex over POS tags. However, we don't have perfect dependency parse trees so not too sure if it's overkill.