### PR TITLE
increment version number to push latest OmnibusDA code to bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "org.allenai"
 
 name := "deep-qa"
 
-version := "0.1.5"
+version := "0.2.1"
 
 scalaVersion := "2.11.7"
 


### PR DESCRIPTION
I already ran `sbt publish`, and aristo compiles fine now.