### PR TITLE
rename SpanPredictionInstance to CharacterSpanInstance

### DIFF
--- a/src/main/scala/org/allenai/deep_qa/data/Instance.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/Instance.scala
@@ -108,7 +108,7 @@ case class SnliInstance(
   * given a question. Used for Stanford Question Answering Dataset (SQuAD)
   * and NewsQA dataset.
   */
-case class SpanPredictionInstance(
+case class CharacterSpanInstance(
   question: String,
   passage: String,
   override val label: Option[(Int, Int)]

--- a/src/main/scala/org/allenai/deep_qa/data/NewsQaDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/NewsQaDatasetReader.scala
@@ -9,8 +9,8 @@ import java.io.StringReader
 import org.json4s._
 import org.json4s.native.JsonMethods.parse
 
-class NewsQaDatasetReader(fileUtil: FileUtil) extends DatasetReader[SpanPredictionInstance] {
-  override def readFile(filename: String): Dataset[SpanPredictionInstance] = {
+class NewsQaDatasetReader(fileUtil: FileUtil) extends DatasetReader[CharacterSpanInstance] {
+  override def readFile(filename: String): Dataset[CharacterSpanInstance] = {
     val reader = new StringReader(fileUtil.readFileContents(filename))
     // read the NewsQA data and discard "bad" questions and questions that
     // do not have an answer present in the passage.
@@ -29,7 +29,7 @@ class NewsQaDatasetReader(fileUtil: FileUtil) extends DatasetReader[SpanPredicti
       val answerStart = labelSplit(0).toInt
       // end character of answer in passage, exclusive
       val answerEnd = labelSplit(1).toInt
-      SpanPredictionInstance(questionText, passageText, Some(answerStart, answerEnd))
+      CharacterSpanInstance(questionText, passageText, Some(answerStart, answerEnd))
     }}
     Dataset(instances)
   }

--- a/src/main/scala/org/allenai/deep_qa/data/SquadDatasetReader.scala
+++ b/src/main/scala/org/allenai/deep_qa/data/SquadDatasetReader.scala
@@ -6,8 +6,8 @@ import com.mattg.util.FileUtil
 import org.json4s._
 import org.json4s.native.JsonMethods.parse
 
-class SquadDatasetReader(fileUtil: FileUtil) extends DatasetReader[SpanPredictionInstance] {
-  override def readFile(filename: String): Dataset[SpanPredictionInstance] = {
+class SquadDatasetReader(fileUtil: FileUtil) extends DatasetReader[CharacterSpanInstance] {
+  override def readFile(filename: String): Dataset[CharacterSpanInstance] = {
     val json = parse(fileUtil.readFileContents(filename))
     val instanceTuples = for {
       JObject(article) <- json \ "data"
@@ -33,7 +33,7 @@ class SquadDatasetReader(fileUtil: FileUtil) extends DatasetReader[SpanPredictio
       val uniqueAnswers = answerTuples.groupBy(identity).mapValues(_.size).toList.sortBy(-_._2)
       val mostFrequentAnswer = uniqueAnswers.head._1
       val (answerStart, answerText) = mostFrequentAnswer
-      SpanPredictionInstance(question, paragraph, Some(answerStart, answerStart + answerText.size))
+      CharacterSpanInstance(question, paragraph, Some(answerStart, answerStart + answerText.size))
     }}
     Dataset(instances)
   }

--- a/src/test/scala/org/allenai/deep_qa/data/NewsQaDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/NewsQaDatasetReaderSpec.scala
@@ -99,10 +99,10 @@ class NewsQaDatasetReaderSpec extends FlatSpecLike with Matchers {
     dataset.instances.size should be (4)
 
     // note that whitespace was trimmed following the answer.
-    dataset.instances(0) should be(SpanPredictionInstance(question1, fixedPassage1, Some(288, 290)))
-    dataset.instances(1) should be(SpanPredictionInstance(question2, fixedPassage2, Some(34, 59)))
-    dataset.instances(2) should be(SpanPredictionInstance(question3, fixedPassage3, Some(103, 126)))
-    dataset.instances(3) should be(SpanPredictionInstance(question4, fixedPassage4, Some(191, 222)))
+    dataset.instances(0) should be(CharacterSpanInstance(question1, fixedPassage1, Some(288, 290)))
+    dataset.instances(1) should be(CharacterSpanInstance(question2, fixedPassage2, Some(34, 59)))
+    dataset.instances(2) should be(CharacterSpanInstance(question3, fixedPassage3, Some(103, 126)))
+    dataset.instances(3) should be(CharacterSpanInstance(question4, fixedPassage4, Some(191, 222)))
 
     dataset.instances(0).passage.substring(dataset.instances(0).label.get._1, dataset.instances(0).label.get._2) should be (answer1)
     dataset.instances(1).passage.substring(dataset.instances(1).label.get._1, dataset.instances(1).label.get._2) should be (answer2)

--- a/src/test/scala/org/allenai/deep_qa/data/SquadDatasetReaderSpec.scala
+++ b/src/test/scala/org/allenai/deep_qa/data/SquadDatasetReaderSpec.scala
@@ -149,13 +149,13 @@ class SquadDatasetReaderSpec extends FlatSpecLike with Matchers {
 
     val fixedParagraph1 = paragraph1.replace("\\\"", "\"")
     dataset.instances.size should be(7)
-    dataset.instances(0) should be(SpanPredictionInstance(question11, fixedParagraph1, Some(515, 515 + answer11.size)))
-    dataset.instances(1) should be(SpanPredictionInstance(question12, fixedParagraph1, Some(92, 92 + answer12.size)))
-    dataset.instances(2) should be(SpanPredictionInstance(question21, paragraph2, Some(3, 3 + answer21.size)))
-    dataset.instances(3) should be(SpanPredictionInstance(question22, paragraph2, Some(222, 222 + answer22.size)))
-    dataset.instances(4) should be(SpanPredictionInstance(question23, paragraph2, Some(49, 49 + answer23.size)))
-    dataset.instances(5) should be(SpanPredictionInstance(question31, paragraph3, Some(105, 105 + answer31.size)))
-    dataset.instances(6) should be(SpanPredictionInstance(question32, paragraph3, Some(286, 286 + answer32.size)))
+    dataset.instances(0) should be(CharacterSpanInstance(question11, fixedParagraph1, Some(515, 515 + answer11.size)))
+    dataset.instances(1) should be(CharacterSpanInstance(question12, fixedParagraph1, Some(92, 92 + answer12.size)))
+    dataset.instances(2) should be(CharacterSpanInstance(question21, paragraph2, Some(3, 3 + answer21.size)))
+    dataset.instances(3) should be(CharacterSpanInstance(question22, paragraph2, Some(222, 222 + answer22.size)))
+    dataset.instances(4) should be(CharacterSpanInstance(question23, paragraph2, Some(49, 49 + answer23.size)))
+    dataset.instances(5) should be(CharacterSpanInstance(question31, paragraph3, Some(105, 105 + answer31.size)))
+    dataset.instances(6) should be(CharacterSpanInstance(question32, paragraph3, Some(286, 286 + answer32.size)))
   }
 }
 


### PR DESCRIPTION
This PR renames the `SpanPredictionInstance` class to `CharacterSpanInstance`. 

We made that change in the python code, but not in scala.