### PR TITLE
Fixes to answer DA questions with the deep_qa solver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "org.allenai"
 
 name := "deep-qa"
 
-version := "0.2.1"
+version := "0.2.2"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/protobuf/message.proto
+++ b/src/main/protobuf/message.proto
@@ -17,6 +17,7 @@ enum InstanceType {
   TRUE_FALSE = 1;
   MULTIPLE_TRUE_FALSE = 2;
   QUESTION_ANSWER = 3;
+  SPAN_PREDICTION = 4;
 }
 
 message Instance {
@@ -37,6 +38,12 @@ message Instance {
   // background sentences.  In these instances, all other fields will be empty (except the type),
   // and this will be populated.
   repeated Instance contained_instances = 5;
+
+  // Direct answer or other instances need a string background passage. This represents that.
+  string passage = 6;
+
+  // The label for span prediction is represented as a tuple of Ints
+  repeated int32 span = 7;
 }
 
 message QuestionRequest {

--- a/src/main/protobuf/message.proto
+++ b/src/main/protobuf/message.proto
@@ -17,7 +17,7 @@ enum InstanceType {
   TRUE_FALSE = 1;
   MULTIPLE_TRUE_FALSE = 2;
   QUESTION_ANSWER = 3;
-  SPAN_PREDICTION = 4;
+  CHARACTER_SPAN = 4;
 }
 
 message Instance {
@@ -42,7 +42,7 @@ message Instance {
   // Direct answer or other instances need a string background passage. This represents that.
   string passage = 6;
 
-  // The label for span prediction is represented as a tuple of Ints
+  // The label for CharacterSpanInstance is represented as a tuple of Ints
   repeated int32 span = 7;
 }
 

--- a/src/main/protobuf/message.proto
+++ b/src/main/protobuf/message.proto
@@ -40,10 +40,9 @@ message Instance {
   repeated Instance contained_instances = 5;
 
   // Direct answer or other instances need a string background passage. This represents that.
+  // This kind of overlaps with background_instances.
   string passage = 6;
 
-  // The label for CharacterSpanInstance is represented as a tuple of Ints
-  repeated int32 span = 7;
 }
 
 message QuestionRequest {

--- a/src/main/protobuf/message.proto
+++ b/src/main/protobuf/message.proto
@@ -40,7 +40,9 @@ message Instance {
   repeated Instance contained_instances = 5;
 
   // Direct answer or other instances need a string background passage. This represents that.
-  // This kind of overlaps with background_instances.
+  // This partially overlaps with background_instances, except that this field expects a single
+  // concatenated string of background knowledge, whlie background_instances takes a collection
+  // of background Instance objects (e.g. tuples).
   string passage = 6;
 
 }

--- a/src/main/python/server.py
+++ b/src/main/python/server.py
@@ -73,7 +73,7 @@ class SolverServer(message_pb2.SolverServiceServicer):
             question = instance_message.question
             options = instance_message.answer_options
             instance = QuestionAnswerInstance(question, options, None, None)
-        elif instance_type == message_pb2.SPAN_PREDICTION:
+        elif instance_type == message_pb2.CHARACTER_SPAN:
             question = instance_message.question
             passage = instance_message.passage
             instance = CharacterSpanInstance(question, passage, None, None)

--- a/src/main/python/server.py
+++ b/src/main/python/server.py
@@ -20,6 +20,7 @@ from deep_qa.common.checks import ensure_pythonhashseed_set
 from deep_qa.common.params import get_choice
 from deep_qa.models import concrete_models
 
+from deep_qa.data.instances.character_span_instance import CharacterSpanInstance
 from deep_qa.data.instances.true_false_instance import TrueFalseInstance
 from deep_qa.data.instances.multiple_true_false_instance import MultipleTrueFalseInstance
 from deep_qa.data.instances.question_answer_instance import QuestionAnswerInstance
@@ -72,6 +73,10 @@ class SolverServer(message_pb2.SolverServiceServicer):
             question = instance_message.question
             options = instance_message.answer_options
             instance = QuestionAnswerInstance(question, options, None, None)
+        elif instance_type == message_pb2.SPAN_PREDICTION:
+            question = instance_message.question
+            passage = instance_message.passage
+            instance = CharacterSpanInstance(question, passage, None, None)
         else:
             raise RuntimeError("Unrecognized instance type: " + instance_type)
         if instance_message.background_instances:

--- a/src/main/scala/org/allenai/deep_qa/solver/Client.scala
+++ b/src/main/scala/org/allenai/deep_qa/solver/Client.scala
@@ -65,30 +65,30 @@ class Client(host: String, port: Int) extends LazyLogging {
             Seq()
           )
         })
-        MessageInstance(instanceType, questionText, answerOptions, backgroundInstances, Seq())
+        MessageInstance(instanceType, questionText, answerOptions, backgroundInstances)
       }
       case i: QuestionAnswerInstance => {
         val instanceType = InstanceType.QUESTION_ANSWER
         val questionText = i.question
         val answerOptions = i.answers
-        MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq(), "", Seq())
+        MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq(), "")
       }
       case i: MultipleTrueFalseInstance[_] => {
         val instanceType = InstanceType.MULTIPLE_TRUE_FALSE
         val containedInstances = i.instances.map(instanceToMessage)
-        MessageInstance(instanceType, "", Seq(), Seq(), containedInstances, "", Seq())
+        MessageInstance(instanceType, "", Seq(), Seq(), containedInstances, "")
       }
       case i: TrueFalseInstance => {
         val instanceType = InstanceType.TRUE_FALSE
         val questionText = i.statement
         val answerOptions = Seq()
-        MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq(), "", Seq())
+        MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq(), "")
       }
       case i: CharacterSpanInstance => {
         val instanceType = InstanceType.CHARACTER_SPAN
         val questionText = i.question
         val passageText = i.passage
-        MessageInstance(instanceType, questionText, Seq(), Seq(), Seq(), passageText, Seq())
+        MessageInstance(instanceType, questionText, Seq(), Seq(), Seq(), passageText)
       }
     }
   }

--- a/src/main/scala/org/allenai/deep_qa/solver/Client.scala
+++ b/src/main/scala/org/allenai/deep_qa/solver/Client.scala
@@ -4,6 +4,7 @@ import scala.sys.process.Process
 
 import org.allenai.deep_qa.data.Instance
 import org.allenai.deep_qa.data.BackgroundInstance
+import org.allenai.deep_qa.data.CharacterSpanInstance
 import org.allenai.deep_qa.data.QuestionAnswerInstance
 import org.allenai.deep_qa.data.MultipleTrueFalseInstance
 import org.allenai.deep_qa.data.TrueFalseInstance
@@ -70,18 +71,24 @@ class Client(host: String, port: Int) extends LazyLogging {
         val instanceType = InstanceType.QUESTION_ANSWER
         val questionText = i.question
         val answerOptions = i.answers
-        MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq())
+        MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq(), "", Seq())
       }
       case i: MultipleTrueFalseInstance[_] => {
         val instanceType = InstanceType.MULTIPLE_TRUE_FALSE
         val containedInstances = i.instances.map(instanceToMessage)
-        MessageInstance(instanceType, "", Seq(), Seq(), containedInstances)
+        MessageInstance(instanceType, "", Seq(), Seq(), containedInstances, "", Seq())
       }
       case i: TrueFalseInstance => {
         val instanceType = InstanceType.TRUE_FALSE
         val questionText = i.statement
         val answerOptions = Seq()
-        MessageInstance(instanceType, questionText, answerOptions, Seq())
+        MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq(), "", Seq())
+      }
+      case i: CharacterSpanInstance => {
+        val instanceType = InstanceType.SPAN_PREDICTION
+        val questionText = i.question
+        val passageText = i.passage
+        MessageInstance(instanceType, questionText, Seq(), Seq(), Seq(), passageText, Seq())
       }
     }
   }

--- a/src/main/scala/org/allenai/deep_qa/solver/Client.scala
+++ b/src/main/scala/org/allenai/deep_qa/solver/Client.scala
@@ -85,7 +85,7 @@ class Client(host: String, port: Int) extends LazyLogging {
         MessageInstance(instanceType, questionText, answerOptions, Seq(), Seq(), "", Seq())
       }
       case i: CharacterSpanInstance => {
-        val instanceType = InstanceType.SPAN_PREDICTION
+        val instanceType = InstanceType.CHARACTER_SPAN
         val questionText = i.question
         val passageText = i.passage
         MessageInstance(instanceType, questionText, Seq(), Seq(), Seq(), passageText, Seq())


### PR DESCRIPTION
This PR has a couple of fixes that will hopefully let us answer DA questions with the deep_qa solver.

- [X] added fields to the protobuf config to represent the `CharacterSpanInstance`
- [X] updated scala code to create a `MessageInstance` from a `CharacterSpanInstance`
- [X] updated python code to be able to read a protobuf message with a `CharacterSpanInstance` in it.