### PR TITLE
Enable solving DA questions w/ python server

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "org.allenai"
 
 name := "deep-qa"
 
-version := "0.2.3"
+version := "0.2.4"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/protobuf/message.proto
+++ b/src/main/protobuf/message.proto
@@ -52,7 +52,7 @@ message QuestionRequest {
 }
 
 enum QuestionType {
-  UNDEFINED = 0;
+  UNDEFINED_QUESTION_TYPE = 0;
   MULTIPLE_CHOICE = 1;
   DIRECT_ANSWER = 2;
 }

--- a/src/main/protobuf/message.proto
+++ b/src/main/protobuf/message.proto
@@ -51,9 +51,20 @@ message QuestionRequest {
   Instance question = 1;
 }
 
+enum QuestionType {
+  UNDEFINED = 0;
+  MULTIPLE_CHOICE = 1;
+  DIRECT_ANSWER = 2;
+}
+
 message QuestionResponse {
+  QuestionType type = 1;
+
   // This returns one double for each answer option, in the same order in which the answer options
   // were given.  If there were no answer options (e.g., for TRUE_FALSE instances), this will be a
-  // single double, giving the score of "true".
-  repeated double scores = 1;
+  // single double, giving the score of "true". This is only used for multiple choice questions.
+  repeated double scores = 2;
+
+  // This returns one string for the question. This is only used for direct answer questions.
+  string answer = 3;
 }

--- a/src/main/python/proto/message_pb2.py
+++ b/src/main/python/proto/message_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='message.proto',
   package='deep_qa',
   syntax='proto3',
-  serialized_pb=_b('\n\rmessage.proto\x12\x07\x64\x65\x65p_qa\"\xcb\x01\n\x08Instance\x12#\n\x04type\x18\x01 \x01(\x0e\x32\x15.deep_qa.InstanceType\x12\x10\n\x08question\x18\x02 \x01(\t\x12\x16\n\x0e\x61nswer_options\x18\x03 \x03(\t\x12/\n\x14\x62\x61\x63kground_instances\x18\x04 \x03(\x0b\x32\x11.deep_qa.Instance\x12.\n\x13\x63ontained_instances\x18\x05 \x03(\x0b\x32\x11.deep_qa.Instance\x12\x0f\n\x07passage\x18\x06 \x01(\t\"6\n\x0fQuestionRequest\x12#\n\x08question\x18\x01 \x01(\x0b\x32\x11.deep_qa.Instance\"\"\n\x10QuestionResponse\x12\x0e\n\x06scores\x18\x01 \x03(\x01*o\n\x0cInstanceType\x12\r\n\tUNDEFINED\x10\x00\x12\x0e\n\nTRUE_FALSE\x10\x01\x12\x17\n\x13MULTIPLE_TRUE_FALSE\x10\x02\x12\x13\n\x0fQUESTION_ANSWER\x10\x03\x12\x12\n\x0e\x43HARACTER_SPAN\x10\x04\x32X\n\rSolverService\x12G\n\x0e\x41nswerQuestion\x12\x18.deep_qa.QuestionRequest\x1a\x19.deep_qa.QuestionResponse\"\x00\x42\x15\n\x13org.allenai.deep_qab\x06proto3')
+  serialized_pb=_b('\n\rmessage.proto\x12\x07\x64\x65\x65p_qa\"\xcb\x01\n\x08Instance\x12#\n\x04type\x18\x01 \x01(\x0e\x32\x15.deep_qa.InstanceType\x12\x10\n\x08question\x18\x02 \x01(\t\x12\x16\n\x0e\x61nswer_options\x18\x03 \x03(\t\x12/\n\x14\x62\x61\x63kground_instances\x18\x04 \x03(\x0b\x32\x11.deep_qa.Instance\x12.\n\x13\x63ontained_instances\x18\x05 \x03(\x0b\x32\x11.deep_qa.Instance\x12\x0f\n\x07passage\x18\x06 \x01(\t\"6\n\x0fQuestionRequest\x12#\n\x08question\x18\x01 \x01(\x0b\x32\x11.deep_qa.Instance\"W\n\x10QuestionResponse\x12#\n\x04type\x18\x01 \x01(\x0e\x32\x15.deep_qa.QuestionType\x12\x0e\n\x06scores\x18\x02 \x03(\x01\x12\x0e\n\x06\x61nswer\x18\x03 \x01(\t*o\n\x0cInstanceType\x12\r\n\tUNDEFINED\x10\x00\x12\x0e\n\nTRUE_FALSE\x10\x01\x12\x17\n\x13MULTIPLE_TRUE_FALSE\x10\x02\x12\x13\n\x0fQUESTION_ANSWER\x10\x03\x12\x12\n\x0e\x43HARACTER_SPAN\x10\x04*S\n\x0cQuestionType\x12\x1b\n\x17UNDEFINED_QUESTION_TYPE\x10\x00\x12\x13\n\x0fMULTIPLE_CHOICE\x10\x01\x12\x11\n\rDIRECT_ANSWER\x10\x02\x32X\n\rSolverService\x12G\n\x0e\x41nswerQuestion\x12\x18.deep_qa.QuestionRequest\x1a\x19.deep_qa.QuestionResponse\"\x00\x42\x15\n\x13org.allenai.deep_qab\x06proto3')
 )
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -53,17 +53,47 @@ _INSTANCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=324,
-  serialized_end=435,
+  serialized_start=377,
+  serialized_end=488,
 )
 _sym_db.RegisterEnumDescriptor(_INSTANCETYPE)
 
 InstanceType = enum_type_wrapper.EnumTypeWrapper(_INSTANCETYPE)
+_QUESTIONTYPE = _descriptor.EnumDescriptor(
+  name='QuestionType',
+  full_name='deep_qa.QuestionType',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='UNDEFINED_QUESTION_TYPE', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='MULTIPLE_CHOICE', index=1, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='DIRECT_ANSWER', index=2, number=2,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=490,
+  serialized_end=573,
+)
+_sym_db.RegisterEnumDescriptor(_QUESTIONTYPE)
+
+QuestionType = enum_type_wrapper.EnumTypeWrapper(_QUESTIONTYPE)
 UNDEFINED = 0
 TRUE_FALSE = 1
 MULTIPLE_TRUE_FALSE = 2
 QUESTION_ANSWER = 3
 CHARACTER_SPAN = 4
+UNDEFINED_QUESTION_TYPE = 0
+MULTIPLE_CHOICE = 1
+DIRECT_ANSWER = 2
 
 
 
@@ -172,9 +202,23 @@ _QUESTIONRESPONSE = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='scores', full_name='deep_qa.QuestionResponse.scores', index=0,
-      number=1, type=1, cpp_type=5, label=3,
+      name='type', full_name='deep_qa.QuestionResponse.type', index=0,
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='scores', full_name='deep_qa.QuestionResponse.scores', index=1,
+      number=2, type=1, cpp_type=5, label=3,
       has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='answer', full_name='deep_qa.QuestionResponse.answer', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -191,17 +235,19 @@ _QUESTIONRESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=288,
-  serialized_end=322,
+  serialized_end=375,
 )
 
 _INSTANCE.fields_by_name['type'].enum_type = _INSTANCETYPE
 _INSTANCE.fields_by_name['background_instances'].message_type = _INSTANCE
 _INSTANCE.fields_by_name['contained_instances'].message_type = _INSTANCE
 _QUESTIONREQUEST.fields_by_name['question'].message_type = _INSTANCE
+_QUESTIONRESPONSE.fields_by_name['type'].enum_type = _QUESTIONTYPE
 DESCRIPTOR.message_types_by_name['Instance'] = _INSTANCE
 DESCRIPTOR.message_types_by_name['QuestionRequest'] = _QUESTIONREQUEST
 DESCRIPTOR.message_types_by_name['QuestionResponse'] = _QUESTIONRESPONSE
 DESCRIPTOR.enum_types_by_name['InstanceType'] = _INSTANCETYPE
+DESCRIPTOR.enum_types_by_name['QuestionType'] = _QUESTIONTYPE
 
 Instance = _reflection.GeneratedProtocolMessageType('Instance', (_message.Message,), dict(
   DESCRIPTOR = _INSTANCE,

--- a/src/main/python/server.py
+++ b/src/main/python/server.py
@@ -67,7 +67,7 @@ class SolverServer(message_pb2.SolverServiceServicer):
         else:
             response.type = message_pb2.DIRECT_ANSWER
             begin_span_idx, end_span_idx = scores
-            string_response = instance.passage_text[begin_span_idx, end_span_idx]
+            string_response = instance.passage_text[begin_span_idx:end_span_idx]
             response.answer = string_response
         return response
 

--- a/src/main/scala/org/allenai/deep_qa/parse/QuestionInterpreter.scala
+++ b/src/main/scala/org/allenai/deep_qa/parse/QuestionInterpreter.scala
@@ -20,7 +20,7 @@ case class ScienceQuestion(sentences: Seq[String], answers: Seq[Answer])
 
 // Direct Answer responses should use the answer field, and multiple choice responses
 // should use the scores field (probabilities over possible choices).
-case class ScienceAnswer(scores: Seq[Double], answer: String)
+case class ScienceAnswer(scores: Option[Seq[Double]], answer: Option[String])
 
 /**
  * A QuestionInterpreter takes a question and converts it into a representation usable by other

--- a/src/main/scala/org/allenai/deep_qa/parse/QuestionInterpreter.scala
+++ b/src/main/scala/org/allenai/deep_qa/parse/QuestionInterpreter.scala
@@ -18,6 +18,10 @@ import org.allenai.nlpstack.parse.poly.core.{Token => PPToken}
 case class Answer(text: String, isCorrect: Boolean)
 case class ScienceQuestion(sentences: Seq[String], answers: Seq[Answer])
 
+// Direct Answer responses should use the answer field, and multiple choice responses
+// should use the scores field (probabilities over possible choices).
+case class ScienceAnswer(scores: Seq[Double], answer: String)
+
 /**
  * A QuestionInterpreter takes a question and converts it into a representation usable by other
  * parts of the system.

--- a/src/main/scala/org/allenai/deep_qa/solver/Client.scala
+++ b/src/main/scala/org/allenai/deep_qa/solver/Client.scala
@@ -49,11 +49,11 @@ class Client(host: String, port: Int) extends LazyLogging {
     instance match {
       case i: CharacterSpanInstance => {
         // We are answering a direct answer question.
-        ScienceAnswer(Seq(), response.answer)
+        ScienceAnswer(None, Some(response.answer))
       }
       case _ => {
         // We are answering a multiple choice question
-        ScienceAnswer(response.scores, "")
+        ScienceAnswer(Some(response.scores), None)
       }
     }
   }

--- a/src/main/scala/org/allenai/deep_qa/solver/Client.scala
+++ b/src/main/scala/org/allenai/deep_qa/solver/Client.scala
@@ -14,6 +14,7 @@ import org.allenai.deep_qa.message.InstanceType
 import org.allenai.deep_qa.message.SolverServiceGrpc
 import org.allenai.deep_qa.message.QuestionRequest
 import org.allenai.deep_qa.message.QuestionResponse
+import org.allenai.deep_qa.parse.ScienceAnswer
 
 import com.mattg.util.FileUtil
 import com.typesafe.scalalogging.LazyLogging
@@ -43,9 +44,18 @@ class Client(host: String, port: Int) extends LazyLogging {
     channel.shutdown.awaitTermination(5, TimeUnit.SECONDS)
   }
 
-  def answerQuestion(instance: Instance): Seq[Double] = {
+  def answerQuestion(instance: Instance): ScienceAnswer = {
     val response = sendMessage(instanceToMessage(instance))
-    response.scores
+    instance match {
+      case i: CharacterSpanInstance => {
+        // We are answering a direct answer question.
+        ScienceAnswer(Seq(), response.answer)
+      }
+      case _ => {
+        // We are answering a multiple choice question
+        ScienceAnswer(response.scores, "")
+      }
+    }
   }
 
   def instanceToMessage(instance: Instance): MessageInstance = {
@@ -115,7 +125,7 @@ object Client {
       BackgroundInstance(TrueFalseInstance("statement 4", None), Seq("background 4"))
     ), None)
 
-    val scores = client.answerQuestion(instance)
+    val scores = client.answerQuestion(instance).scores
     println(s"Scores: [${scores.mkString(" ")}]")
     client.shutdown()
   }


### PR DESCRIPTION
I want to update the `deep_qa` submodule to include https://github.com/allenai/deep_qa/pull/246, so don't look at this until that's in.

This PR lets the Python server send an appropriate `QuestionResponse` when we get a DA question. The server should switch seamlessly based on what sort of model it's dealing with, hence the conditional check for `BidirectionalAttentionFlow`

next, I believe have to make the scala client properly read this `QuestionResponse` and compose it into a `SolverResponse` that can be used by the rest of aristo --- but that's a PR for the aristo repo, i think.