### PR TITLE
Temp changes to run demo as a solver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ ENV PYTHONPATH /deep_qa:$PYTHONPATH
 
 EXPOSE 50051
 
-COPY ./eb4b1b35/ /efs/data/dlfa/models/eb4b1b35/
+COPY ./bidaf-tf-moretrained /tmp/models/bidaf-tf-moretrained/bidaf
 
 ENTRYPOINT ["python", "src/main/python/server.py", "50051"]

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "org.allenai"
 
 name := "deep-qa"
 
-version := "0.2.5"
+version := "0.2.5-SNAPSHOT"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/python/server.py
+++ b/src/main/python/server.py
@@ -66,9 +66,10 @@ class SolverServer(message_pb2.SolverServiceServicer):
                 response.scores.extend(score)
         else:
             response.type = message_pb2.DIRECT_ANSWER
-            begin_span_idx, end_span_idx = scores
-            string_response = instance.passage_text[begin_span_idx:end_span_idx]
-            response.answer = string_response
+            # begin_span_idx, end_span_idx = scores
+            # string_response = instance.passage_text[begin_span_idx:end_span_idx]
+            # response.answer = string_response
+            response.answer = scores
         return response
 
     def read_instance_message(self, instance_message):


### PR DESCRIPTION
Making a PR so it's easier to access, as opposed to going to my local branch.
*Note that these instructions probably aren't optimal, but I was mainly focused on getting this to work so I didn't explore "properly" doing it once it worked*

To run this as a solver:
1) Get Min's demo running on your machine.  Checkout [this branch](https://github.com/allenai/bi-att-flow/tree/demo) of allenai/bi-att-flow, and run `python run-demo.py`.  Also change [this line](https://github.com/allenai/deep_qa/blob/bidaf_use_web_demo/deep_qa/models/reading_comprehension/bidirectional_attention.py#L251) of our bidaf code to point to the right IP address (and be sure you do that inside of `deep_qa_experiments/deep_qa`).
2) set up docker on your EC2 instance. this may or may not be painful, but it took me quite awhile.
3)  I've assumed you've cloned this repo to your EC2 instance that has docker. I'll refer to this repo/ it's location on your instance as "`deep_qa_experiments`" henceforth. Pull down this branch, and run `sbt publishLocal` in this repo. Note that the version is `0.2.5-SNAPSHOT`, and my changes to the aristo repo accordingly look for that version.
4) The dockerfile doesn't matter _too_ much, since we aren't using a loaded keras bidaf model. But in `deep_qa_experiments`, I have a folder called `bidaf-tf-moretrained/`. I've uploaded it to EFS at `/efs/data/dlfa/models/bidaf-tf-moretrained/`, so you can grab it from there and put it in `deep_qa_experiments`.
5) In addition, I have this _same_ folder at `/tmp/models/bidaf-tf-moretrained/`. so also copy it there.
6) now you're ready to build the dockerfile. Go to `deep_qa_experiments` and run: `docker build --no-cache -t deep_qa .`
7) Now you can run the docker container from anywhere. I'm presuming you're running this on your AI2 laptop, and that your directory structure mirrors that of your remote system. This might need tweaking otherwise, let me know. The command basically maps folders on your local machine to docker (or maybe its the other way around..) I'd open up a new terminal tab, ssh to your EC2 instance, then run: 
`docker run --rm -p 50051:50051 -v <Full path to EC2 home>:<Full path to EC2 home> -v /tmp:/tmp --name deep_qa <path to deep_qa experiments>/bidaf-tf-moretrained/bidaf_squad.json`
 8) In my case, it was:
`docker run --rm -p 50051:50051 -v /home/nelsonl:/home/nelsonl -v /tmp:/tmp --name deep_qa deep_qa /home/nelsonl/Documents/Github/deep_qa_experiments/bidaf-tf-1epoch/bidaf_squad.json`
9) Verify that things seem to have worked out. You should see the model summary of BiDAF after running the docker command.
10) Now, clone [my branch of aristo](https://github.com/nelson-liu/aristo/tree/fix_da_solver_logging). I'll refer to where you cloned it as `aristo`.
11) I'd open another terminal window at this point, since I like leaving the thing running docker open to view the output. In `aristo`, run `sbt`, then `project deepqa-solver`, then `re-start`. You should see something like the following: [gist link](https://gist.github.com/nelson-liu/b69efc156e9a04d81a5ae46ee5604fcc)
12) At this point, open yet another terminal window and cd to `aristo`. From here, run `bin/evaluate run -l deepqa 414`. You may or may not need `sudo` for this command. 415 refers to the evar #, which in this case evaluates against omnibus 8 NDDA dev.
13) If everything went well, you should see it answering questions. The tab with docker open should begin spitting out blocks of the form:
```
-------------------------------------------------
question text: <Question text that it's using, transformed>
passage text: <passage text that it's using>
response: <what the model answered>
-------------------------------------------------
```
14) alternatively, after it's done, you can navigate to [the ef evar for 415](http://aristo-ef-prod.dev.ai2:8082/evaluations/415), and click on "details". If you look at a question, you can click "solver responses", then keep expanding. you should see JSON with the transformed question and the generated paragraph. This is useful for post-hoc evaluation of how the passages were, since it's easy to see the generated passages / transformed question / solver response all in one place.

Let me know if you have trouble running this / if there are steps i can take out, etc.
